### PR TITLE
Fix incorrect dest paths for output files, add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Fixes #7 

With the config:
```js
swigtemplates: {
  options: {
    locales: ['en-US', 'es-US'],
    defaultLocale: 'en-US',
    translationFunction: tr
  },
  production: {
    expand: true,
    cwd: 'src/swig/',
    src: ['**/*.swig'],
    dest: 'build/'
  },
}
```
and `src/swig` structure:
```
dir/file.html.swig
index.html.swig
```
at the moment grunt-swigtemplates produces:
```
build\index.html.swig\src\swig\index.html
build\lol\file.html.swig\src\swig\lol\file.html

build\index.html.swig\es-US\src\swig\index.html
build\lol\file.html.swig\es-US\src\swig\lol\file.html
```
With the proposed changes it will be:
```
build\index.html
build\lol\file.html

build\es-US\index.html
build\es-US\lol\file.html
```